### PR TITLE
fix: fix deprecated 'cls.syntax' problem

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,9 @@ class PuppetLint(RubyLinter):
 
     """Provides an interface to puppet-lint."""
 
-    syntax = 'puppet'
+    defaults = {
+        'selector': 'source.puppet'
+    }
     cmd = ('puppet-lint', '--log-format', '%{line}:%{column}:%{kind}:%{message}', '*')
     executable = None
     regex = (


### PR DESCRIPTION
> SublimeLinter: ERROR: puppetlint: Defining 'cls.syntax' has no effect anymore. Use http://www.sublimelinter.com/en/stable/linter_settings.html#selector instead.

Slove the below problem.